### PR TITLE
Fixes problem with coping empty fields.

### DIFF
--- a/lib/solr2solr.coffee
+++ b/lib/solr2solr.coffee
@@ -26,8 +26,10 @@ class SolrToSolr
   prepareDocuments: (docs, start) =>
     for doc in docs
       newDoc = {}
-      newDoc[copyField]             = doc[copyField]               for copyField in @config.copy
-      newDoc[transform.destination] = doc[transform.source]        for transform in @config.transform
+      for copyField in @config.copy 
+        newDoc[copyField] = doc[copyField] if doc[copyField]?
+      for transform in @config.transform
+        newDoc[transform.destination] = doc[transform.source] if doc[transform.source]?        
       for fab in @config.fabricate
         vals = fab.fabricate(newDoc, start)
         newDoc[fab.name] = vals if vals?


### PR DESCRIPTION
...ue for the field in question.  Example error is: The request sent by the client was syntactically incorrect (ERROR: [doc=4034/E0DQ3] Error adding field 'my_field'='undefined')
